### PR TITLE
Comment out connector for unproxied connection in Confluence

### DIFF
--- a/projects/server.xml
+++ b/projects/server.xml
@@ -1,0 +1,104 @@
+<Server port="8000" shutdown="SHUTDOWN">
+    <Service name="Tomcat-Standalone">
+        <!--
+         ==============================================================================================================
+         DEFAULT - Direct connector with no proxy, for unproxied HTTP access to Confluence.
+
+         If using a http/https proxy, comment out this connector.
+         ==============================================================================================================
+        -->
+        <!--
+        <Connector port="8090" connectionTimeout="20000" redirectPort="8443"
+                   maxThreads="48" maxPostSize="16777216" minSpareThreads="10"
+                   enableLookups="false" acceptCount="10" URIEncoding="UTF-8"
+                   protocol="org.apache.coyote.http11.Http11NioProtocol"/>
+        -->
+        <!--
+         ==============================================================================================================
+         HTTP - Proxying Confluence via Apache or Nginx over HTTP
+
+         If you're proxying traffic to Confluence over HTTP, uncomment the connector below and comment out the others.
+         Make sure you provide the right information for proxyName and proxyPort.
+
+         For more information see:
+            Apache - https://confluence.atlassian.com/x/4xQLM
+            nginx  - https://confluence.atlassian.com/x/TgSvEg
+
+         ==============================================================================================================
+        -->
+
+        <!--
+        <Connector port="8090" connectionTimeout="20000" redirectPort="8443"
+                   maxThreads="48" maxPostSize="16777216" minSpareThreads="10"
+                   enableLookups="false" acceptCount="10" URIEncoding="UTF-8"
+                   protocol="org.apache.coyote.http11.Http11NioProtocol"
+                   scheme="http" proxyName="lib-confluence.princeton.edu" proxyPort="80"/>
+        -->
+
+        <!--
+         ==============================================================================================================
+         HTTPS - Direct connector with no proxy, for unproxied HTTPS access to Confluence.
+
+         For more info see https://confluence.atlassian.com/x/s3UC
+         ==============================================================================================================
+        -->
+
+        <!--
+        <Connector port="8443" maxHttpHeaderSize="8192"
+                   maxThreads="150" maxPostSize="16777216" minSpareThreads="25"
+                   protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+                   enableLookups="false" disableUploadTimeout="true"
+                   acceptCount="100" scheme="https" secure="true"
+                   clientAuth="false" sslProtocol="TLSv1.2" sslEnabledProtocols="TLSv1.2" SSLEnabled="true"
+                   URIEncoding="UTF-8" keystorePass="Sanitized by Support Utility>"/>
+        -->
+
+        <!--
+         ==============================================================================================================
+         HTTPS - Proxying Confluence via Apache or Nginx over HTTPS
+
+         If you're proxying traffic to Confluence over HTTPS, uncomment the connector below and comment out the others.
+         Make sure you provide the right information for proxyName and proxyPort.
+
+         For more information see:
+            Apache - https://confluence.atlassian.com/x/PTT3MQ
+            nginx  - https://confluence.atlassian.com/x/cNIvMw
+         ==============================================================================================================
+        -->
+
+        <Connector port="8090" connectionTimeout="20000" redirectPort="8443"
+                   maxThreads="48" maxPostSize="16777216" minSpareThreads="10"
+                   enableLookups="false" acceptCount="10" URIEncoding="UTF-8"
+                   protocol="org.apache.coyote.http11.Http11NioProtocol"
+                   scheme="https" secure="true" proxyName="lib-confluence.princeton.edu" proxyPort="443"/>
+
+        <Engine name="Standalone" defaultHost="localhost">
+            <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false" startStopThreads="4">
+                <Context path="" docBase="../confluence" reloadable="false" useHttpOnly="true">
+                    <!-- Logging configuration for Confluence is specified in confluence/WEB-INF/classes/log4j.properties -->
+                    <Manager pathname=""/>
+                    <Valve className="org.apache.catalina.valves.StuckThreadDetectionValve" threshold="60"/>
+
+                    <!-- http://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Access_Log_Valve -->
+                    <Valve className="org.apache.catalina.valves.AccessLogValve"
+                           directory="logs"
+                           maxDays="30"
+                           pattern="%t %{X-AUSERNAME}o %I %h %r %s %Dms %b %{Referer}i %{User-Agent}i"
+                           prefix="conf_access_log"
+                           requestAttributesEnabled="true"
+                           rotatable="true"
+                           suffix=".log"
+                    />
+
+                    <!-- http://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Remote_IP_Valve -->
+                    <Valve className="org.apache.catalina.valves.RemoteIpValve" />
+                </Context>
+
+                <Context path="${confluence.context.path}/synchrony-proxy" docBase="../synchrony-proxy"
+                         reloadable="false" useHttpOnly="true">
+                    <Valve className="org.apache.catalina.valves.StuckThreadDetectionValve" threshold="60"/>
+                </Context>
+            </Host>
+        </Engine>
+    </Service>
+</Server>


### PR DESCRIPTION
This adds the working configuration in the server.xml file to fix the Tomcat server config error we received after upgrading Confluence 